### PR TITLE
[BE] 메인 페이지 리팩토링

### DIFF
--- a/be/src/main/java/com/issuetrackermax/controller/filter/FilterController.java
+++ b/be/src/main/java/com/issuetrackermax/controller/filter/FilterController.java
@@ -18,7 +18,7 @@ public class FilterController {
 
 	@GetMapping()
 	public ApiResponse<FilterResponse> getFilteredIssues(@ModelAttribute FilterRequest filterRequest) {
-		FilterResponse maintPageIssue = filterService.getMainPageIssue(filterRequest);
-		return ApiResponse.success(maintPageIssue);
+		FilterResponse mainPageIssue = filterService.getMainPageIssue(filterRequest);
+		return ApiResponse.success(mainPageIssue);
 	}
 }

--- a/be/src/main/java/com/issuetrackermax/controller/filter/FilterController.java
+++ b/be/src/main/java/com/issuetrackermax/controller/filter/FilterController.java
@@ -1,18 +1,12 @@
 package com.issuetrackermax.controller.filter;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.issuetrackermax.controller.ApiResponse;
+import com.issuetrackermax.controller.filter.dto.FilterRequest;
 import com.issuetrackermax.controller.filter.dto.FilterResponse;
-import com.issuetrackermax.controller.filter.dto.IssueResponse;
-import com.issuetrackermax.domain.filter.FilterMapper;
-import com.issuetrackermax.domain.filter.FilterResultVO;
 import com.issuetrackermax.service.filter.FilterService;
 
 import lombok.RequiredArgsConstructor;
@@ -20,26 +14,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 public class FilterController {
-	private final FilterMapper filterMapper;
 	private final FilterService filterService;
 
 	@GetMapping()
-	public ApiResponse<FilterResponse> getFilteredIssues(@RequestParam Map<String, Object> parameters) {
-		List<FilterResultVO> resultVOS = filterMapper.getFilteredList(parameters);
-		if (resultVOS.size() == 0) {
-			return ApiResponse.success();
-		}
-		List<IssueResponse> issueResponses = resultVOS.stream()
-			.map(i -> IssueResponse.builder().resultVO(i).build())
-			.collect(
-				Collectors.toList());
-		FilterResponse filterResponse = FilterResponse.builder()
-			.labelCount(filterService.getLabelCount())
-			.mileStoneCount(filterService.getMilestoneCount())
-			.closedIssueCount(filterService.getClosedIssueCount())
-			.openIssueCount(filterService.getOpenIssueCount())
-			.issues(issueResponses)
-			.build();
-		return ApiResponse.success(filterResponse);
+	public ApiResponse<FilterResponse> getFilteredIssues(@ModelAttribute FilterRequest filterRequest) {
+		FilterResponse maintPageIssue = filterService.getMainPageIssue(filterRequest);
+		return ApiResponse.success(maintPageIssue);
 	}
 }

--- a/be/src/main/java/com/issuetrackermax/controller/filter/dto/AssigneeResponse.java
+++ b/be/src/main/java/com/issuetrackermax/controller/filter/dto/AssigneeResponse.java
@@ -19,8 +19,11 @@ public class AssigneeResponse {
 		this.name = name;
 	}
 
-	public static List<AssigneeResponse> convertToAssigneeResponseList(String laassigneeIds, String assigneeNames) {
-		List<String> ids = List.of(laassigneeIds.split(","));
+	public static List<AssigneeResponse> convertToAssigneeResponseList(String assigneeIds, String assigneeNames) {
+		if (assigneeIds == null) {
+			return null;
+		}
+		List<String> ids = List.of(assigneeIds.split(","));
 		List<String> names = List.of(assigneeNames.split(","));
 		return IntStream.range(0, ids.size())
 			.mapToObj(i -> AssigneeResponse.builder()

--- a/be/src/main/java/com/issuetrackermax/controller/filter/dto/FilterRequest.java
+++ b/be/src/main/java/com/issuetrackermax/controller/filter/dto/FilterRequest.java
@@ -1,0 +1,26 @@
+package com.issuetrackermax.controller.filter.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FilterRequest {
+	private Boolean issueIsOpen;
+	private Long writer;
+	private Long milestone;
+	private Long label;
+	private Long assignee;
+
+	@Builder
+	public FilterRequest(Boolean issueIsOpen, Long writer, Long milestone, Long label, Long assignee) {
+		this.issueIsOpen = issueIsOpen;
+		this.writer = writer;
+		this.milestone = milestone;
+		this.label = label;
+		this.assignee = assignee;
+	}
+}

--- a/be/src/main/java/com/issuetrackermax/controller/filter/dto/LabelResponse.java
+++ b/be/src/main/java/com/issuetrackermax/controller/filter/dto/LabelResponse.java
@@ -20,6 +20,9 @@ public class LabelResponse {
 	}
 
 	public static List<LabelResponse> convertToLabelResponseList(String labelIds, String labelTitles) {
+		if (labelIds == null) {
+			return null;
+		}
 		List<String> ids = List.of(labelIds.split(","));
 		List<String> titles = List.of(labelTitles.split(","));
 		return IntStream.range(0, ids.size())

--- a/be/src/main/java/com/issuetrackermax/domain/filter/FilterMapper.java
+++ b/be/src/main/java/com/issuetrackermax/domain/filter/FilterMapper.java
@@ -1,13 +1,14 @@
 package com.issuetrackermax.domain.filter;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
+
+import com.issuetrackermax.controller.filter.dto.FilterRequest;
 
 @Mapper
 public interface FilterMapper {
 
-	List<FilterResultVO> getFilteredList(Map<String, Object> param);
+	List<FilterResultVO> getFilteredList(FilterRequest param);
 
 }

--- a/be/src/main/java/com/issuetrackermax/service/filter/FilterService.java
+++ b/be/src/main/java/com/issuetrackermax/service/filter/FilterService.java
@@ -1,7 +1,15 @@
 package com.issuetrackermax.service.filter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
+import com.issuetrackermax.controller.filter.dto.FilterRequest;
+import com.issuetrackermax.controller.filter.dto.FilterResponse;
+import com.issuetrackermax.controller.filter.dto.IssueResponse;
+import com.issuetrackermax.domain.filter.FilterMapper;
+import com.issuetrackermax.domain.filter.FilterResultVO;
 import com.issuetrackermax.domain.issue.IssueRepository;
 import com.issuetrackermax.domain.label.LabelRepository;
 import com.issuetrackermax.domain.milestone.MilestoneRepository;
@@ -11,9 +19,34 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class FilterService {
+	private final FilterMapper filterMapper;
 	private final MilestoneRepository milestoneRepository;
 	private final IssueRepository issueRepository;
 	private final LabelRepository labelRepository;
+
+	public FilterResponse getMainPageIssue(FilterRequest filterRequest) {
+		List<FilterResultVO> filterResultVOS = getFilterVO(filterRequest);
+		return FilterResponse.builder()
+			.labelCount(getLabelCount())
+			.mileStoneCount(getMilestoneCount())
+			.closedIssueCount(getClosedIssueCount())
+			.openIssueCount(getOpenIssueCount())
+			.issues(getIssues(filterResultVOS))
+			.build();
+	}
+
+	public List<IssueResponse> getIssues(List<FilterResultVO> filterResultVOS) {
+		if (filterResultVOS.size() == 0) {
+			return null;
+		}
+		return filterResultVOS.stream()
+			.map(i -> IssueResponse.builder().resultVO(i).build())
+			.collect(Collectors.toList());
+	}
+
+	public List<FilterResultVO> getFilterVO(FilterRequest filterRequest) {
+		return filterMapper.getFilteredList(filterRequest);
+	}
 
 	public Long getMilestoneCount() {
 		return milestoneRepository.getMilestoneCount();

--- a/be/src/test/java/com/issuetrackermax/controller/ControllerTestSupport.java
+++ b/be/src/test/java/com/issuetrackermax/controller/ControllerTestSupport.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetrackermax.controller.auth.AuthController;
 import com.issuetrackermax.controller.filter.FilterController;
 import com.issuetrackermax.controller.member.MemberController;
-import com.issuetrackermax.domain.filter.FilterMapper;
 import com.issuetrackermax.service.filter.FilterService;
 import com.issuetrackermax.service.jwt.JwtService;
 import com.issuetrackermax.service.member.MemberService;
@@ -35,6 +34,4 @@ public abstract class ControllerTestSupport {
 	@MockBean
 	protected FilterService filterService;
 
-	@MockBean
-	protected FilterMapper filterMapper;
 }

--- a/be/src/test/java/com/issuetrackermax/domain/filter/FilterMapperTest.java
+++ b/be/src/test/java/com/issuetrackermax/domain/filter/FilterMapperTest.java
@@ -3,7 +3,6 @@ package com.issuetrackermax.domain.filter;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.issuetrackermax.controller.filter.dto.FilterRequest;
 import com.issuetrackermax.domain.IntegrationTestSupport;
 import com.issuetrackermax.domain.assignee.AssigneeRepository;
 import com.issuetrackermax.domain.assignee.entity.Assignee;
@@ -109,7 +109,7 @@ class FilterMapperTest extends IntegrationTestSupport {
 	@Test
 	void getFilteredListWithIssueOpen() {
 		// given
-		Map<String, Object> issueIsOpen = Map.of("issueIsOpen", 1);
+		FilterRequest issueIsOpen = FilterRequest.builder().issueIsOpen(true).build();
 
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
@@ -122,7 +122,7 @@ class FilterMapperTest extends IntegrationTestSupport {
 	@Test
 	void getFilteredListWithIssueClosed() {
 		// given
-		Map<String, Object> issueIsOpen = Map.of("issueIsOpen", 0);
+		FilterRequest issueIsOpen = FilterRequest.builder().issueIsOpen(false).build();
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
 		// then
@@ -142,8 +142,7 @@ class FilterMapperTest extends IntegrationTestSupport {
 		Long issueId = issueRepository.save(issue);
 		Assignee assignee = makeAssignee(issueId, memberId);
 		Long issigneeId = assigneeRepository.save(assignee);
-
-		Map<String, Object> issueIsOpen = Map.of("assignee", memberId);
+		FilterRequest issueIsOpen = FilterRequest.builder().assignee(memberId).build();
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
 		// then
@@ -155,6 +154,7 @@ class FilterMapperTest extends IntegrationTestSupport {
 	@Test
 	void getFilteredListWithLabelNewId() {
 
+		// given
 		Label label = makeLabel("label_title_test", "label_description3", "0#9999", "0#8888");
 		Long labelId = labelRepository.save(label);
 
@@ -166,9 +166,7 @@ class FilterMapperTest extends IntegrationTestSupport {
 			.labelId(labelId)
 			.build();
 		Long issueLabelId2 = issueLabelRepository.save(issueWithLabel);
-
-		// given
-		Map<String, Object> issueIsOpen = Map.of("label", labelId, "issueIsOpen", 0);
+		FilterRequest issueIsOpen = FilterRequest.builder().label(labelId).issueIsOpen(false).build();
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
 		// then
@@ -183,9 +181,8 @@ class FilterMapperTest extends IntegrationTestSupport {
 		Milestone milestone = makeMilestone(true, "milestone_title3", "milestone_description");
 		Long milestoneId = milestoneRepository.save(milestone);
 		Issue issue = makeIssue(false, "issue_title_test", milestoneId, 1L);
-
 		Long issueId2 = issueRepository.save(issue);
-		Map<String, Object> issueIsOpen = Map.of("milestone", milestoneId, "issueIsOpen", 0);
+		FilterRequest issueIsOpen = FilterRequest.builder().milestone(milestoneId).issueIsOpen(false).build();
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
 		// then
@@ -202,9 +199,11 @@ class FilterMapperTest extends IntegrationTestSupport {
 		Long milestoneId = milestoneRepository.save(milestone);
 		Issue issue3 = makeIssue(true, "issue_title_test", milestoneId, 1L);
 		Long issueId2 = issueRepository.save(issue3);
-		Map<String, Object> issueIsOpen = Map.of("milestone", milestoneId, "issueIsOpen", 1);
+		FilterRequest issueIsOpen = FilterRequest.builder().milestone(milestoneId).issueIsOpen(true).build();
+
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
+
 		// then
 		assertExtractingWithParameter(filteredList, "issue_title_test", null, "June", true, null,
 			null, null, null, "milestone_title_test");
@@ -216,8 +215,8 @@ class FilterMapperTest extends IntegrationTestSupport {
 		// given
 
 		Issue issue3 = makeIssue(true, "issue_title_test", 1L, 1L);
-		Long issueId2 = issueRepository.save(issue3);
-		Map<String, Object> issueIsOpen = Map.of("writer", 1, "issueIsOpen", 1);
+		issueRepository.save(issue3);
+		FilterRequest issueIsOpen = FilterRequest.builder().writer(1L).issueIsOpen(true).build();
 		// when
 		List<FilterResultVO> filteredList = filterMapper.getFilteredList(issueIsOpen);
 		// then


### PR DESCRIPTION
## Feature 
메인 페이지 리팩토링 및 메인페이지 리팩토링에 의해 생긴 코드들 테스트 코드 작성

## Tasks
- [x] 메인 페이지 RequestParameter를 Map형태에서 FilterRequest로 수정
- [x] FilterController에서 FilterMapper를 통해 값을 가져오는 것이 아니라 FilterService에서 FilterMapper를 통해 값을 가져온다.

이전엔 Filtering 조건에 맞지 않은 Issue가 없을 때, Response로 
```
"success" : "true",
"data" : null 
```
data를 null 처리를 하였지만 
'''
```
"success": true,
"data": {
        "labelCount": 2,
        "mileStoneCount": 1,
        "openIssueCount": 1,
        "closedIssueCount": 1,
        "issues": null
    }
```
data안에 issues만 null로 처리